### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/1](https://github.com/karlitos1337/5d/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block that restricts the GITHUB_TOKEN to only require the least necessary access. For this workflow, all current steps merely need to read repository contents, so the block should specify `permissions: contents: read` as a minimal starting point. This can be added either at the top of the file (root level) to apply to all jobs, or inside the `build` job itself for job-level scoping. For simplicity and future-proofing, adding it at the root level is preferred. The change should be made at the top of the file, right after the `name:` declaration and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
