### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-code-examples.yml
+++ b/.github/workflows/test-code-examples.yml
@@ -1,4 +1,6 @@
 name: Test Code Examples
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/2](https://github.com/karlitos1337/5d/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. Since the job only checks out code and runs tests, the only permission required is read access to repository contents. Add a `permissions: contents: read` block either at the top level (applies to all jobs unless overridden) or under the specific job definition (applies only to that job). The most universally recommended placement is immediately after the workflow `name` and before the `on` block (top-level).

Edit the `.github/workflows/test-code-examples.yml` file to insert:

```yaml
permissions:
  contents: read
```

immediately after the `name:` line (line 1).

No additional imports, methods, or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
