### PR TITLE
Potential fix for code scanning alert no. 32: Incomplete URL substring sanitization

### DIFF
--- a/docs/5d-map/sw.js
+++ b/docs/5d-map/sw.js
@@ -117,9 +117,15 @@ function isStaticAsset(url) {
 
 // Helper: Check if URL is an external CDN
 function isExternalCDN(url) {
-  return url.includes('unpkg.com') || 
-         url.includes('cdn.jsdelivr.net') ||
-         url.includes('cdnjs.cloudflare.com');
+  try {
+    const hostname = (new URL(url, location.href)).hostname;
+    return hostname === 'unpkg.com' ||
+           hostname === 'cdn.jsdelivr.net' ||
+           hostname === 'cdnjs.cloudflare.com';
+  } catch (e) {
+    // If URL parsing fails, treat as not CDN
+    return false;
+  }
 }
 
 // Strategy 1: Network-first (try network, fallback to cache)


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/32](https://github.com/karlitos1337/5d/security/code-scanning/32)

To correctly identify whether a URL points to an external CDN host, the code should parse the URL and run a check on its `hostname` property rather than performing a substring check. This involves using the built-in `URL` constructor to parse the URL, which is available in modern browsers, including service worker contexts. The function `isExternalCDN(url)` should be updated to extract and check only the actual hostname against the known CDN hostnames (`unpkg.com`, `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`). The code block in docs/5d-map/sw.js, specifically lines related to `isExternalCDN`, should be replaced accordingly.

Only the region defining the `isExternalCDN` function (lines 119–123) needs to be modified. No other code needs to change (unless new usages appear elsewhere in other snippets not shown). This fix does not require any third-party libraries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
