### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: 5D Tests & Validation
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/3](https://github.com/karlitos1337/5d/security/code-scanning/3)

To fix this problem, explicitly add a `permissions` key with restrictive settings (`contents: read`) to the workflow. This can be done at the top-level (recommended unless a specific job requires custom permissions) so that all jobs and all uses of the `GITHUB_TOKEN` default to this least-privilege setting. To avoid altering existing workflow behavior, place the `permissions` block immediately after the `name` field and before `on:` at the root of `.github/workflows/test.yml`.

- Edit `.github/workflows/test.yml`.
- Insert the following lines after the workflow `name:` line:
  ```yaml
  permissions:
    contents: read
  ```
- No imports, methods, or other definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
