### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/web/bewusstsein_evolution.html
+++ b/web/bewusstsein_evolution.html
@@ -995,14 +995,35 @@
             labels.forEach((label, idx) => {
                 const sliderDiv = document.createElement('div');
                 sliderDiv.className = 'slider-control';
-                sliderDiv.innerHTML = `
-                    <label>
-                        ${label}
-                        <span class="slider-value" id="value_${selectedDim}_${idx}">${data[idx]}</span>
-                    </label>
-                    <input type="range" min="1" max="99" value="${data[idx]}" 
-                           oninput="updateMetric('${selectedDim}', ${idx}, this.value)">
-                `;
+                
+                // Create label
+                const labelEl = document.createElement('label');
+                
+                // Label text
+                labelEl.appendChild(document.createTextNode(label));
+                
+                // Value span
+                const spanEl = document.createElement('span');
+                spanEl.className = 'slider-value';
+                spanEl.id = `value_${selectedDim}_${idx}`;
+                spanEl.textContent = data[idx];
+                labelEl.appendChild(document.createTextNode(' ')); // spacing
+                labelEl.appendChild(spanEl);
+                
+                // Input
+                const inputEl = document.createElement('input');
+                inputEl.type = 'range';
+                inputEl.min = '1';
+                inputEl.max = '99';
+                inputEl.value = data[idx];
+                inputEl.oninput = function() {
+                    updateMetric(selectedDim, idx, this.value);
+                };
+                
+                // Append elements
+                sliderDiv.appendChild(labelEl);
+                sliderDiv.appendChild(inputEl);
+                
                 container.appendChild(sliderDiv);
             });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/12](https://github.com/karlitos1337/5d/security/code-scanning/12)

The best way to fix this issue is to ensure that any user-controlled data (such as `selectedDim`) interpolated into HTML via `.innerHTML` is properly escaped to prevent HTML meta-characters from being interpreted. One way is to avoid using `.innerHTML` with untrusted content and instead use safer DOM insertion techniques (e.g., textContent, setAttribute, or manual creation of individual DOM nodes and assigning their properties directly). In this context, for each location where `${selectedDim}` is interpolated into the template (lines 1001 and in IDs), those sections should be escaped or, better yet, assign them via DOM property setters rather than HTML injection.

The replacement should:
- Change the dynamic construction to create divs, labels, and spans using `document.createElement`, setting `.textContent` and `.id` safely, instead of constructing HTML with template literals and assigning to `.innerHTML`.
- Specifically, replace the code within the forEach loop (lines 995-1005) to build up the slider control using DOM methods, assigning only safe values.
- No new dependencies required.
- Only edit the block beginning at line 995 in web/bewusstsein_evolution.html.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
