### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-5d-metadata.yml
+++ b/.github/workflows/validate-5d-metadata.yml
@@ -1,4 +1,6 @@
 name: Validate 5D Metadata & Structure
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/5](https://github.com/karlitos1337/5d/security/code-scanning/5)

To fix this problem, add a `permissions:` block to the workflow YAML file, which will restrict the GITHUB_TOKEN permissions used by the workflow. The block should be placed at the root of the workflow file, directly beneath the `name:` line (or above/below the `on:` block), ensuring that all jobs and steps in the workflow inherit these minimal permissions unless overridden in specific jobs. Based on the steps shown, the workflow only reads repository contents and does not write to issues, pull requests, or other areas, so setting `contents: read` is sufficient and recommended. No additional imports, methods, or definitions are needed—just the insertion of the appropriate YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
