### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-experiments.yml
+++ b/.github/workflows/validate-experiments.yml
@@ -1,4 +1,6 @@
 name: Validate Experiments
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/4](https://github.com/karlitos1337/5d/security/code-scanning/4)

To fix the problem, add a `permissions` key either to the root of the workflow or to the individual job. The CodeQL suggestion is to use:
```yaml
permissions:
  contents: read
```
This ensures the workflow and jobs can read repository contents but cannot modify them. Since this workflow uploads artifacts (which does not require `contents: write`), the minimal permission is sufficient. The explicit block should be added near the top (after `name:` and optionally after/on the same level as `on:`), or within the job’s definition. The best practice is to add to the workflow root so all jobs default to least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
