### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,6 @@
 name: Frontmatter & Index Validation
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/6](https://github.com/karlitos1337/5d/security/code-scanning/6)

To address the issue, add a `permissions` key to restrict the default privileges of the GITHUB_TOKEN. The minimal and recommended setting here is `contents: read`, which allows read-only access to repository contents for the duration of the workflow. This should be added at the root level of the workflow file (just after the `name:` block), so all jobs inherit this policy unless overridden. No other code or configuration changes are needed for the current steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
