### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/external/sources/awesome-datascience-live/.github/workflows/action.yml
+++ b/external/sources/awesome-datascience-live/.github/workflows/action.yml
@@ -1,4 +1,6 @@
 name: Check Markdown links
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "* */24 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/7](https://github.com/karlitos1337/5d/security/code-scanning/7)

To fix the issue, we should add an explicit `permissions` block that restricts the GITHUB_TOKEN permissions to the minimal required level for the job. Since the job only checks out code and runs analysis, it needs only read access. Add `permissions: contents: read` at the root level of the workflow file (above `jobs:`) so all jobs in the workflow inherit restricted permissions. Edit external/sources/awesome-datascience-live/.github/workflows/action.yml to insert the `permissions` block after the workflow name and before `on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
