### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/web/5d-map/sw.js
+++ b/web/5d-map/sw.js
@@ -117,9 +117,18 @@ function isStaticAsset(url) {
 
 // Helper: Check if URL is an external CDN
 function isExternalCDN(url) {
-  return url.includes('unpkg.com') || 
-         url.includes('cdn.jsdelivr.net') ||
-         url.includes('cdnjs.cloudflare.com');
+  try {
+    const parsed = new URL(url, self.location.origin); // Support relative URLs
+    const hostname = parsed.hostname;
+    return (
+      hostname === 'unpkg.com' || hostname.endsWith('.unpkg.com') ||
+      hostname === 'cdn.jsdelivr.net' || hostname.endsWith('.cdn.jsdelivr.net') ||
+      hostname === 'cdnjs.cloudflare.com' || hostname.endsWith('.cdnjs.cloudflare.com')
+    );
+  } catch (e) {
+    // If url cannot be parsed, treat as not external CDN
+    return false;
+  }
 }
 
 // Strategy 1: Network-first (try network, fallback to cache)


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/8](https://github.com/karlitos1337/5d/security/code-scanning/8)

The fix is to parse the URL and check its host component explicitly against a whitelist or known host(s), rather than looking for a substring anywhere in the URL string. In this case, instead of `url.includes('unpkg.com')`, we should parse the URL (using the standard `URL` constructor available in browsers/Service Workers) and compare its `hostname` property to exactly 'unpkg.com' or, if subdomains are to be included, check that it is either 'unpkg.com' or ends with `.unpkg.com`.

This fix should be applied to the `isExternalCDN(url)` function in `web/5d-map/sw.js`. No new dependencies are needed since the `URL` object is built into browsers. The change is safe as it preserves the original logic but enhances precision.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
