### PR TITLE
Potential fix for code scanning alert no. 26: Incomplete URL substring sanitization

### DIFF
--- a/external/sources/sitedorks-master/sitedorks.py
+++ b/external/sources/sitedorks-master/sitedorks.py
@@ -140,15 +140,18 @@ if aArguments.ubb:
             if sInScope["type"] == "web":
                 lInScopeValues = sInScope["value"].lower().split(",")
                 for sInScopeValue in lInScopeValues:
+                    # Parse the value to extract the hostname if needed
+                    parsed_url = urllib.parse.urlparse(sInScopeValue)
+                    sHost = parsed_url.hostname if parsed_url.hostname else sInScopeValue
                     if (
-                        sInScopeValue.endswith("amazonaws.com")
-                        or sInScopeValue.endswith("cloudfront.net")
-                        or sInScopeValue.endswith("azurefd.net")
-                        or sInScopeValue.endswith("azurewebsites.net")
+                        sHost.endswith("amazonaws.com")
+                        or sHost.endswith("cloudfront.net")
+                        or sHost.endswith("azurefd.net")
+                        or sHost.endswith("azurewebsites.net")
                     ):
-                        sDomain = sInScopeValue
+                        sDomain = sHost
                     else:
-                        dl3, dl2, dl1 = extract(sInScopeValue)
+                        dl3, dl2, dl1 = extract(sHost)
                         sDomain = dl2 + "." + dl1
 
                     if (
@@ -162,18 +165,21 @@ if aArguments.ubb:
                         dDomainsInScope[sDomain] = sLine["slug"]
 
         for sOutScope in sLine["out_scope"]:
+                    # Parse the value to extract the hostname if needed
+                    parsed_url = urllib.parse.urlparse(sOutScopeValue)
+                    sHost = parsed_url.hostname if parsed_url.hostname else sOutScopeValue
             if sOutScope["type"] == "web":
                 lOutScopeValues = sOutScope["value"].lower().split(",")
                 for sOutScopeValue in lOutScopeValues:
                     if (
-                        sOutScopeValue.endswith("amazonaws.com")
-                        or sOutScopeValue.endswith("cloudfront.net")
-                        or sOutScopeValue.endswith("azurefd.net")
-                        or sOutScopeValue.endswith("azurewebsites.net")
+                        sHost.endswith("amazonaws.com")
+                        or sHost.endswith("cloudfront.net")
+                        or sHost.endswith("azurefd.net")
+                        or sHost.endswith("azurewebsites.net")
                     ):
-                        sDomain = sOutScopeValue
+                        sDomain = sHost
                     else:
-                        dl3, dl2, dl1 = extract(sOutScopeValue)
+                        dl3, dl2, dl1 = extract(sHost)
                         sDomain = f"{dl2}.{dl1}"
 
                     if (


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/26](https://github.com/karlitos1337/5d/security/code-scanning/26)

To fix the problem, we must ensure that we're checking the hostname of the given value, not performing a substring or suffix test on an arbitrary string which may contain a full URL or path. The safest approach is to parse each value using `urllib.parse.urlparse` to extract the hostname, then check whether that hostname ends with the allowed suffix. If the value is a bare domain (not a URL), we'll use it directly; if it's a URL, we'll extract the hostname. Replace all the `.endswith(...)` conditions in both the "in scope" and "out scope" iterators with proper parsing and hostname checking. Specifically, within the affected blocks (lines 144-148 and 169-173), parse the scope value, extract the hostname, and check whether the hostname ends with the approved suffix.

You will need to edit both the "in_scope" and "out_scope" blocks and insert (or reuse) the `urlparse` import that is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
