### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/external/sources/awesome-piracy-main/index.html
+++ b/external/sources/awesome-piracy-main/index.html
@@ -61,8 +61,12 @@
 		// Change the theme
 		function changeCSS( theme )
 		{
-			document.querySelector( 'link' ).href
-					= `https://cdn.jsdelivr.net/npm/bootswatch@${bootswatchVersion}/dist/${theme}/bootstrap.min.css`;
+			const allowedThemes = ['darkly', 'united', 'flatly', 'quartz'];
+			if (!allowedThemes.includes(theme)) {
+				theme = defaultTheme;
+			}
+			document.querySelector('link').href =
+				`https://cdn.jsdelivr.net/npm/bootswatch@${bootswatchVersion}/dist/${theme}/bootstrap.min.css`;
 		}
 
 		// Set the default theme


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/11](https://github.com/karlitos1337/5d/security/code-scanning/11)

To fix the problem, we must ensure that only allowed theme names can be used in the URL interpolation. The best approach is to restrict the value of `theme` to one of the known valid theme names (`darkly`, `united`, `flatly`, `quartz`). This whitelisting approach neutralizes the risk of malicious or malformed values being injected. The change should be made in the `changeCSS(theme)` function: before updating the stylesheet `href`, check that `theme` is one of the predefined themes. If not, optionally ignore the change or revert to a default theme. Imports are not necessary since this logic can be implemented inline in JavaScript.

Edits are needed only in the region of the function `changeCSS(theme)`, specifically before the assignment to the link's `href`. Also, if the default theme is set programmatically, ensure `defaultTheme` is valid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
