### PR TITLE
Potential fix for code scanning alert no. 33: Incomplete URL substring sanitization

### DIFF
--- a/external/sources/sitedorks-master/sitedorks.py
+++ b/external/sources/sitedorks-master/sitedorks.py
@@ -144,10 +144,10 @@ if aArguments.ubb:
                     parsed_url = urllib.parse.urlparse(sInScopeValue)
                     sHost = parsed_url.hostname if parsed_url.hostname else sInScopeValue
                     if (
-                        sHost.endswith("amazonaws.com")
-                        or sHost.endswith("cloudfront.net")
-                        or sHost.endswith("azurefd.net")
-                        or sHost.endswith("azurewebsites.net")
+                        (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "amazonaws.com"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "cloudfront.net"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "azurefd.net"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "azurewebsites.net"
                     ):
                         sDomain = sHost
                     else:
@@ -172,10 +172,10 @@ if aArguments.ubb:
                 lOutScopeValues = sOutScope["value"].lower().split(",")
                 for sOutScopeValue in lOutScopeValues:
                     if (
-                        sHost.endswith("amazonaws.com")
-                        or sHost.endswith("cloudfront.net")
-                        or sHost.endswith("azurefd.net")
-                        or sHost.endswith("azurewebsites.net")
+                        (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "amazonaws.com"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "cloudfront.net"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "azurefd.net"
+                        or (lambda ex: ex.domain + '.' + ex.suffix)(extract(sHost)) == "azurewebsites.net"
                     ):
                         sDomain = sHost
                     else:


### PR DESCRIPTION
Potential fix for [https://github.com/karlitos1337/5d/security/code-scanning/33](https://github.com/karlitos1337/5d/security/code-scanning/33)

To robustly check whether a host is part of a particular domain (e.g., "amazonaws.com"), we should parse the hostname using a well-tested domain parsing library (such as tldextract, which is already imported), and compare the `registered_domain` portion of the host, rather than simply using `.endswith()`. Specifically:  
- For each `sHost`, use `extract(sHost)` to obtain subdomain, domain, and suffix; combine domain and suffix to get the registered domain.  
- Then compare the registered domain to the string (e.g., "amazonaws.com") using equality, not `.endswith()`.  
- Do this replacement in both "in_scope" and "out_scope" loops.

**What to change:**  
- In lines where `.endswith("amazonaws.com")` and similar cloud service domain checks occur, replace with a comparison of the registered domain, derived via `extract(sHost)`, instead.
- No need to change existing tldextract imports.

**Region to edit:**  
- Lines 147-151 and corresponding region in out_scope loop (lines 175-179).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
