### PR TITLE
⚡ Bolt: Debounce map rendering on year slider input

### DIFF
--- a/web/5d-map/app.js
+++ b/web/5d-map/app.js
@@ -1,6 +1,7 @@
 import { fetchAllData, clearCache } from './modules/api-fetcher.js';
 import { initMap, addLayer, removeLayer } from './modules/map-renderer.js';
 import { createHeatmapLayer, createSchoolMarkers, createIMPLayer, createIMPLegendControl, createTimeHeatmapLayer, createValidationRingLayer, createSourcesLayer, createValidationLegendControl } from './modules/layers.js';
+import { debounce } from './modules/utils.js';
 
 let map;
 let activeLayer = null;
@@ -131,15 +132,19 @@ async function init() {
   document.getElementById('layer-time')?.addEventListener('click', () => activateLayer('time'));
 
   const yearSlider = document.getElementById('year-slider');
+  const updateTimeLayer = debounce((year) => {
+    if (document.getElementById('layer-time')?.classList.contains('btn--primary')) {
+      if (activeLayer) removeLayer(map, activeLayer);
+      activeLayer = createTimeHeatmapLayer(cachedData, year);
+      if (activeLayer) addLayer(map, activeLayer);
+    }
+  }, 50);
+
   yearSlider?.addEventListener('input', (e) => {
     selectedYear = Number(e.target.value);
     const label = document.getElementById('year-label');
     if (label) label.textContent = String(selectedYear);
-    if (document.getElementById('layer-time')?.classList.contains('btn--primary')) {
-      if (activeLayer) removeLayer(map, activeLayer);
-      activeLayer = createTimeHeatmapLayer(cachedData, selectedYear);
-      if (activeLayer) addLayer(map, activeLayer);
-    }
+    updateTimeLayer(selectedYear);
   });
 
   // Auto-Refresh jede Stunde

--- a/web/5d-map/modules/utils.js
+++ b/web/5d-map/modules/utils.js
@@ -1,0 +1,8 @@
+export function debounce(func, wait) {
+  let timeout;
+  return function(...args) {
+    const context = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(context, args), wait);
+  };
+}

--- a/web/5d-map/tests/test-utils.spec.js
+++ b/web/5d-map/tests/test-utils.spec.js
@@ -1,0 +1,40 @@
+import { describe, test, expect, vi } from 'vitest';
+import { debounce } from '../modules/utils.js';
+
+describe('Utils', () => {
+  test('debounce delays execution', () => {
+    vi.useFakeTimers();
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 100);
+
+    debouncedFunc();
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(51);
+    expect(func).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  test('debounce groups multiple calls', () => {
+    vi.useFakeTimers();
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 100);
+
+    debouncedFunc();
+    vi.advanceTimersByTime(50);
+    debouncedFunc();
+    vi.advanceTimersByTime(50);
+    debouncedFunc();
+
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(101);
+    expect(func).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
💡 What: Implemented debouncing (50ms) for the map layer update in the year slider input listener.
🎯 Why: Moving the slider caused a map re-render on every input event (every pixel), causing significant performance overhead and potential jank.
📊 Impact: Decouples UI updates (label) from expensive map operations. Map updates are now batched, improving responsiveness.
🔬 Measurement: Verified with unit tests for debounce utility and Playwright script ensuring UI responsiveness and correctness.

---
*PR created automatically by Jules for task [13092910943945510641](https://jules.google.com/task/13092910943945510641) started by @karlitos1337*