### PR TITLE
⚡ Bolt: Debounce map updates on year slider

### DIFF
--- a/web/5d-map/app.js
+++ b/web/5d-map/app.js
@@ -1,6 +1,7 @@
 import { fetchAllData, clearCache } from './modules/api-fetcher.js';
 import { initMap, addLayer, removeLayer } from './modules/map-renderer.js';
 import { createHeatmapLayer, createSchoolMarkers, createIMPLayer, createIMPLegendControl, createTimeHeatmapLayer, createValidationRingLayer, createSourcesLayer, createValidationLegendControl } from './modules/layers.js';
+import { debounce } from './modules/utils.js';
 
 let map;
 let activeLayer = null;
@@ -130,16 +131,20 @@ async function init() {
   document.getElementById('layer-sources')?.addEventListener('click', () => activateLayer('sources'));
   document.getElementById('layer-time')?.addEventListener('click', () => activateLayer('time'));
 
+  const updateTimeLayer = debounce((year) => {
+    if (document.getElementById('layer-time')?.classList.contains('btn--primary')) {
+      if (activeLayer) removeLayer(map, activeLayer);
+      activeLayer = createTimeHeatmapLayer(cachedData, year);
+      if (activeLayer) addLayer(map, activeLayer);
+    }
+  }, 50);
+
   const yearSlider = document.getElementById('year-slider');
   yearSlider?.addEventListener('input', (e) => {
     selectedYear = Number(e.target.value);
     const label = document.getElementById('year-label');
     if (label) label.textContent = String(selectedYear);
-    if (document.getElementById('layer-time')?.classList.contains('btn--primary')) {
-      if (activeLayer) removeLayer(map, activeLayer);
-      activeLayer = createTimeHeatmapLayer(cachedData, selectedYear);
-      if (activeLayer) addLayer(map, activeLayer);
-    }
+    updateTimeLayer(selectedYear);
   });
 
   // Auto-Refresh jede Stunde

--- a/web/5d-map/modules/utils.js
+++ b/web/5d-map/modules/utils.js
@@ -1,0 +1,8 @@
+export function debounce(func, wait) {
+  let timeout;
+  return function(...args) {
+    const context = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(context, args), wait);
+  };
+}

--- a/web/5d-map/tests/utils.spec.js
+++ b/web/5d-map/tests/utils.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { debounce } from '../modules/utils.js';
+
+describe('debounce', () => {
+  it('should debounce function calls', () => {
+    vi.useFakeTimers();
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 100);
+
+    debouncedFunc();
+    debouncedFunc();
+    debouncedFunc();
+
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+
+    expect(func).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('should execute with correct arguments', () => {
+    vi.useFakeTimers();
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 100);
+
+    debouncedFunc('test');
+    vi.advanceTimersByTime(100);
+
+    expect(func).toHaveBeenCalledWith('test');
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
Implemented a `debounce` utility and applied it to the `year-slider` input event listener in `web/5d-map/app.js`. This prevents the map from re-rendering on every single mouse movement during sliding, while still keeping the label update immediate for good UX. Added unit tests for the debounce utility.

---
*PR created automatically by Jules for task [6861437255878145035](https://jules.google.com/task/6861437255878145035) started by @karlitos1337*