### PR TITLE
🎨 Palette: Improve accessibility for keyboard and screen reader users

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { motion, useScroll, useSpring } from 'framer-motion';
 import { Sun, Moon, Menu, X } from 'lucide-react';
 
@@ -13,7 +13,7 @@ const App = () => {
     restDelta: 0.001
   });
 
-  const sections = [
+  const sections = useMemo(() => [
     { id: 'einleitung', label: 'Einleitung' },
     { id: 'framework', label: '5D-Intelligence Framework' },
     { id: 'methodologie', label: 'Methodik' },
@@ -22,7 +22,7 @@ const App = () => {
     { id: 'implikationen', label: 'Implikationen' },
     { id: 'zukunft', label: 'Zukunftsperspektiven' },
     { id: 'schlussfolgerung', label: 'Schlussfolgerung' }
-  ];
+  ], []);
 
   useEffect(() => {
     document.querySelectorAll('[data-ref]').forEach(el => {
@@ -85,10 +85,13 @@ const App = () => {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [sections]);
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${darkMode ? 'bg-gray-900 text-gray-100' : 'bg-white text-gray-900'}`}>
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-white focus:text-black">
+        Zum Hauptinhalt springen
+      </a>
       {/* Progress bar */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 bg-blue-500 transform-origin-left z-50"
@@ -125,7 +128,8 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={darkMode ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
+                className={`p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -134,7 +138,9 @@ const App = () => {
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={mobileMenuOpen ? 'Menü schließen' : 'Menü öffnen'}
+                aria-expanded={mobileMenuOpen}
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -171,7 +177,7 @@ const App = () => {
       </header>
 
       {/* Main Content */}
-      <main className="pt-16">
+      <main id="main-content" className="pt-16">
         {/* Hero Section */}
         <section id="einleitung" className={`py-20 ${darkMode ? 'bg-gradient-to-br from-gray-800 to-gray-900' : 'bg-gradient-to-br from-blue-50 to-indigo-100'}`}>
           <div className="max-w-4xl mx-auto px-6 text-center">
@@ -388,7 +394,7 @@ const App = () => {
               <div className={`p-6 rounded-xl ${darkMode ? 'bg-gray-800' : 'bg-gray-50'} shadow-lg`}>
                 <h3 className="text-xl font-semibold mb-4">Reliabilität</h3>
                 <p className="mb-4" data-ref="https://www.sbp-journal.com/index.php/sbp/article/view/13907|11">
-                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach's Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
+                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach&apos;s Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
                 </p>
                 <div className="space-y-2">
                   <div className="flex justify-between">


### PR DESCRIPTION
💡 **What:** 
- Added a "Skip to main content" (`Zum Hauptinhalt springen`) link at the top of the app container, visible only when focused via keyboard navigation.
- Added descriptive `aria-label` and `aria-expanded` attributes, alongside focus-visible styling rings, to the Dark Mode and Mobile Menu toggle buttons.

🎯 **Why:** 
To enhance the dashboard's accessibility for users relying on screen readers or keyboard-only navigation. The skip link bypasses the main header navigation, allowing quicker access to core content, while ARIA labels ensure that icon-only interactive elements clearly convey their current and future states (e.g., 'Switch to light mode').

📸 **Before/After:**
- Before: Icon-only buttons lacked screen reader context, and keyboard users were forced to tab through the entire navigation menu to reach the main page content.
- After: Keyboard users can jump straight to the `<main id="main-content">` via a visually hidden, accessible link, and toggle buttons are fully accessible and indicate focus states.

♿ **Accessibility:**
Improved ARIA compliance, enabled bypass blocks (skip links), and enhanced visual focus states for interactive elements, resolving key a11y anti-patterns common in React SPAs.

---
*PR created automatically by Jules for task [10504125789647141995](https://jules.google.com/task/10504125789647141995) started by @karlitos1337*