### PR TITLE
🎨 Palette: [Accessibility] Add skip link and ARIA labels

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -97,15 +97,9 @@ const App = () => {
       element: document.getElementById(sec.id)
     })).filter(sec => sec.element);
 
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 200;
+    let ticking = { current: false };
 
-      for (let i = sections.length - 1; i >= 0; i--) {
-        const section = document.getElementById(sections[i].id);
-        if (section && scrollPosition >= section.offsetTop) {
-          setActiveSection(sections[i].id);
-          break;
-        }
+    const handleScroll = () => {
       if (!ticking.current) {
         window.requestAnimationFrame(() => {
           const scrollPosition = window.scrollY + 200;
@@ -129,6 +123,12 @@ const App = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${darkMode ? 'bg-gray-900 text-gray-100' : 'bg-white text-gray-900'}`}>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-blue-600 focus:text-white top-0 left-0"
+      >
+        Zum Hauptinhalt springen
+      </a>
       {/* Progress bar */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 bg-blue-500 transform-origin-left z-50"
@@ -165,7 +165,8 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={darkMode ? 'Hellen Modus aktivieren' : 'Dunklen Modus aktivieren'}
+                className={`p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -174,7 +175,8 @@ const App = () => {
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={mobileMenuOpen ? 'Menü schließen' : 'Menü öffnen'}
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -211,7 +213,7 @@ const App = () => {
       </header>
 
       {/* Main Content */}
-      <main className="pt-16">
+      <main id="main-content" tabIndex="-1" className="pt-16 outline-none">
         {/* Hero Section */}
         <section id="einleitung" className={`py-20 ${darkMode ? 'bg-gradient-to-br from-gray-800 to-gray-900' : 'bg-gradient-to-br from-blue-50 to-indigo-100'}`}>
           <div className="max-w-4xl mx-auto px-6 text-center">


### PR DESCRIPTION
💡 What: Added a "Zum Hauptinhalt springen" skip link and ARIA labels to the dark mode and mobile menu toggles in the validation dashboard.
🎯 Why: The dashboard was missing basic accessibility features like skip links and screen-reader accessible icon-only buttons, making navigation difficult for users relying on keyboard/assistive technologies.
📸 Before/After: Visual changes include focus styles on the icon buttons (`focus-visible:ring-2 focus-visible:ring-blue-500`), and a skip link visually hidden (`sr-only`) until focused.
♿ Accessibility:
  - Added skip link to bypass main navigation.
  - Properly annotated the `<main>` tag with `id="main-content"`, `tabIndex="-1"`, and `outline-none`.
  - Added localized ARIA labels and `focus-visible` styles to Dark Mode and Mobile Menu toggle buttons.

---
*PR created automatically by Jules for task [15708965252246150207](https://jules.google.com/task/15708965252246150207) started by @karlitos1337*