### PR TITLE
🎨 Palette: Fix skip link target accessibility in 5D Map

### DIFF
--- a/web/5d-map/index.html
+++ b/web/5d-map/index.html
@@ -98,7 +98,7 @@
     </div>
   </header>
 
-  <main id="main-content">
+  <main id="main-content" tabindex="-1" style="outline: none;">
     <div id="map"></div>
     <div id="layer-info" style="display:none;padding:0.5rem 1rem;max-width:640px;margin:0.5rem;background:#fffffe;border:1px solid #e0e0e0;border-radius:0.5rem;">
       <strong>Layer‑Info:</strong> <span id="layer-info-text">—</span>


### PR DESCRIPTION
💡 What: Added `tabindex="-1"` and `style="outline: none;"` to the main content container in the 5D Map application.
🎯 Why: Ensures that the 'Skip to content' link functions correctly for keyboard users by allowing the `<main>` element to receive programmatic focus, and prevents an unsightly default focus ring from appearing when jumping to the main content.
♿ Accessibility: Resolves a critical keyboard navigation bug, adhering to standard skip link patterns documented in the project's accessibility learnings.

---
*PR created automatically by Jules for task [12683017877423216058](https://jules.google.com/task/12683017877423216058) started by @karlitos1337*