### PR TITLE
🎨 Palette: [UX improvement] Add aria-live to dynamic map elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,7 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+
+## 2025-05-05 - [Accessibility] Dynamic Map Updates
+**Learning:** When UI elements like map layer infos or status counters update dynamically based on user interaction, screen readers will ignore the changes unless explicitly told to monitor them.
+**Action:** Always add `aria-live="polite"` (and `aria-atomic="true"` if needed) to dynamic status containers and counters so that assistive technologies announce these vital updates without requiring a page reload.

--- a/docs/5d-map/index.html
+++ b/docs/5d-map/index.html
@@ -80,7 +80,7 @@
         aria-label="Validierung als JSON exportieren">
         Export (JSON)
       </button>
-      <span id="validation-count" style="margin-left:.5rem;font-size:.9rem;color:#444;" title="Anzahl der Validierungs‑Einträge im aktuellen Filter">Filter: <strong>alle</strong> · Einträge: <strong>0</strong></span>
+      <span id="validation-count" aria-live="polite" aria-atomic="true" style="margin-left:.5rem;font-size:.9rem;color:#444;" title="Anzahl der Validierungs‑Einträge im aktuellen Filter">Filter: <strong>alle</strong> · Einträge: <strong>0</strong></span>
       <button 
         id="layer-sources" 
         class="btn"
@@ -100,7 +100,7 @@
 
   <main id="main-content" tabindex="-1">
     <div id="map"></div>
-    <div id="layer-info" style="display:none;padding:0.5rem 1rem;max-width:640px;margin:0.5rem;background:#fffffe;border:1px solid #e0e0e0;border-radius:0.5rem;">
+    <div id="layer-info" aria-live="polite" style="display:none;padding:0.5rem 1rem;max-width:640px;margin:0.5rem;background:#fffffe;border:1px solid #e0e0e0;border-radius:0.5rem;">
       <strong>Layer‑Info:</strong> <span id="layer-info-text">—</span>
     </div>
     <div id="time-controls" style="display:none;padding:0.5rem 1rem;max-width:480px;margin:0.5rem;background:#fffffe;border:1px solid #e0e0e0;border-radius:0.5rem;">


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` (and `aria-atomic="true"`) to the dynamic layer info and validation count elements in the 5D Map interface (`docs/5d-map/index.html`).
🎯 Why: Screen readers were previously unaware when the map layer info or validation counts updated via JavaScript. Now, they will gracefully announce these changes, significantly improving the experience for visually impaired users.
📸 Before/After: Visuals remain entirely unchanged; the improvement is strictly semantic for screen readers.
♿ Accessibility: Screen readers will now automatically announce the dynamic status of map layers and active data filters.

---
*PR created automatically by Jules for task [9135734895020606744](https://jules.google.com/task/9135734895020606744) started by @karlitos1337*