### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in error handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,7 @@
 **Vulnerability:** Client-side encryption of an API key using a hardcoded passphrase before storing it in `localStorage` provides no actual security (security theater) and gives a false sense of protection, while a heuristic scanner could flag it.
 **Learning:** Avoid security theater practices. Store user-provided keys directly in `localStorage` and rename variables/DOM IDs to generic terms (like `serviceToken`) to avoid false positives from CodeQL's clear-text storage rules.
 **Prevention:** Removed `CryptoJS` encryption, directly stored the key in `localStorage`, and renamed `apiKey` references to `serviceToken` across the file.
+## 2026-05-11 - DOM-based XSS in Error Handler
+**Vulnerability:** Directly assigning user-provided or external data (like error.message) to innerHTML.
+**Learning:** Even inside catch blocks where DOMPurify might not be accessible, innerHTML must be avoided. Fallbacks should always use textContent and document.createElement to ensure secure rendering of failure states.
+**Prevention:** Use textContent instead of innerHTML when dealing with dynamic text, especially error outputs that may contain unsanitized input.

--- a/web/templates/5d_forschungsplanung.html
+++ b/web/templates/5d_forschungsplanung.html
@@ -697,7 +697,11 @@
                 }
             } catch (error) {
                 loadingSpinner.classList.add('hidden');
-                aiResponse.innerHTML = `<p class="text-red-500">Netzwerkfehler: ${error.message}</p>`;
+                const errorElement = document.createElement('p');
+                errorElement.className = "text-red-500";
+                errorElement.textContent = `Netzwerkfehler: ${error.message}`;
+                aiResponse.innerHTML = '';
+                aiResponse.appendChild(errorElement);
             }
         }
     </script>


### PR DESCRIPTION
### 🚨 Severity: HIGH

### 💡 Vulnerability
The application previously used `innerHTML` to display the raw `error.message` directly in the DOM inside a `catch` block within `web/templates/5d_forschungsplanung.html`. If an attacker could influence the error message (e.g., through a Man-in-the-Middle attack or a crafted external response), they could inject malicious HTML or JavaScript. This is especially dangerous inside an error handler where sanitization utilities like `DOMPurify` might be unavailable due to import or initialization failures.

### 🎯 Impact
If exploited, an attacker could execute arbitrary JavaScript in the victim's browser context (DOM-based Cross-Site Scripting), leading to session hijacking, unauthorized actions, or data theft.

### 🔧 Fix
Replaced the direct assignment of `error.message` to `innerHTML` with native DOM element creation:
- Created a `<p>` element using `document.createElement`.
- Safely assigned the error message using `textContent`, which treats all input as literal text.
- Appended the element to the container safely using `appendChild`.

### ✅ Verification
- Ran the global `pytest` suite to ensure no regressions.
- Verified the code properly applies `textContent` within the `catch` block.
- Logged the learning inside `.jules/sentinel.md` as required.

---
*PR created automatically by Jules for task [7634183771868687177](https://jules.google.com/task/7634183771868687177) started by @karlitos1337*