### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Exposure in Error Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** Client-side encryption of an API key using a hardcoded passphrase before storing it in `localStorage` provides no actual security (security theater) and gives a false sense of protection, while a heuristic scanner could flag it.
 **Learning:** Avoid security theater practices. Store user-provided keys directly in `localStorage` and rename variables/DOM IDs to generic terms (like `serviceToken`) to avoid false positives from CodeQL's clear-text storage rules.
 **Prevention:** Removed `CryptoJS` encryption, directly stored the key in `localStorage`, and renamed `apiKey` references to `serviceToken` across the file.
+
+## 2026-05-22 - [Information Exposure in Error Handler]
+**Vulnerability:** The error handler in `web/templates/5d_forschungsplanung.html` injected the raw `error.message` directly into the DOM using `innerHTML`. This leaked internal exception details to the user and created a potential DOM-based XSS vulnerability.
+**Learning:** Never expose raw error messages or stack traces to the user interface. Always use generic error messages and safe DOM insertion methods like `document.createElement` and `textContent` when handling untrusted or internal exception strings.
+**Prevention:** Replaced `innerHTML` injection with native DOM element creation (`document.createElement('p')`) and generic error text via `textContent`.

--- a/web/templates/5d_forschungsplanung.html
+++ b/web/templates/5d_forschungsplanung.html
@@ -697,7 +697,11 @@
                 }
             } catch (error) {
                 loadingSpinner.classList.add('hidden');
-                aiResponse.innerHTML = `<p class="text-red-500">Netzwerkfehler: ${error.message}</p>`;
+                aiResponse.innerHTML = '';
+                const errorP = document.createElement('p');
+                errorP.className = 'text-red-500';
+                errorP.textContent = `Netzwerkfehler: Ein unerwarteter Fehler ist aufgetreten.`;
+                aiResponse.appendChild(errorP);
             }
         }
     </script>


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Gemini API response handler previously injected `error.message` directly into the DOM using `innerHTML` within the `catch` block. This caused Information Exposure by leaking raw stack traces or internal exception details to the end-user and posed a DOM-based XSS risk if the error string was manipulated.
🎯 **Impact:** Exposing internal error messages provides attackers with valuable reconnaissance data and the `innerHTML` execution risks malicious script injection in the user's browser.
🔧 **Fix:** Replaced the unsafe `innerHTML` injection with a generic text fallback ("Ein unerwarteter Fehler ist aufgetreten.") using native DOM element creation (`document.createElement`) and `textContent`.
✅ **Verification:** Verified the code changes in `web/templates/5d_forschungsplanung.html` and ran the existing test suite via `pytest test_5d_map_ci.py`. Documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18372827786575267257](https://jules.google.com/task/18372827786575267257) started by @karlitos1337*