### PR TITLE
🎨 Palette: Add aria-pressed state to map layer controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,6 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+## 2026-05-26 - Add aria-pressed state to map layer controls
+**Learning:** Layer control buttons that toggle active layers act like a tab group or toggle buttons. Visually indicating the active state (e.g., with primary colors) is not enough for screen readers. They need explicit ARIA states to understand which layer is currently active.
+**Action:** Always add aria-pressed="true"/"false" to toggle button groups and update them dynamically in JavaScript when the active state changes.

--- a/web/5d-map/app.js
+++ b/web/5d-map/app.js
@@ -41,9 +41,19 @@ function activateLayer(layerName) {
     infoTextEl.textContent = txt;
     infoEl.style.display = 'block';
   }
-  document.querySelectorAll('.btn').forEach(btn => btn.classList.remove('btn--primary'));
+  document.querySelectorAll('.btn').forEach(btn => {
+    btn.classList.remove('btn--primary');
+    if (btn.hasAttribute('aria-pressed')) {
+      btn.setAttribute('aria-pressed', 'false');
+    }
+  });
   const btn = document.getElementById(`layer-${layerName}`);
-  if (btn) btn.classList.add('btn--primary');
+  if (btn) {
+    btn.classList.add('btn--primary');
+    if (btn.hasAttribute('aria-pressed')) {
+      btn.setAttribute('aria-pressed', 'true');
+    }
+  }
 
   switch (layerName) {
     case 'status-quo':

--- a/web/5d-map/index.html
+++ b/web/5d-map/index.html
@@ -35,7 +35,8 @@
         id="layer-status-quo" 
         class="btn btn--primary"
         title="Zeigt Heatmap für Depression & Dropout-Raten weltweit"
-        aria-label="Status Quo Heatmap anzeigen">
+        aria-label="Status Quo Heatmap anzeigen"
+        aria-pressed="true">
         Status Quo
       </button>
       <button 
@@ -49,21 +50,24 @@
         id="layer-schools" 
         class="btn"
         title="Alternative Schulmodelle: Sudbury, Waldorf, Folk High Schools, Tokkatsu"
-        aria-label="Alternative Schulen auf Karte anzeigen">
+        aria-label="Alternative Schulen auf Karte anzeigen"
+        aria-pressed="false">
         Alternative Schulen
       </button>
       <button 
         id="layer-imp" 
         class="btn"
         title="Intrinsisches Motivationspotenzial (IMP = A×IM×R×SP×Au)"
-        aria-label="IMP-Score Choropleth anzeigen">
+        aria-label="IMP-Score Choropleth anzeigen"
+        aria-pressed="false">
         IMP‑Score
       </button>
       <button 
         id="layer-validation" 
         class="btn"
         title="Validierung (Ringe): zeigt Länder/Regionen mit extern verifizierten Daten (validation.json)"
-        aria-label="Validierung (Ringe) anzeigen">
+        aria-label="Validierung (Ringe) anzeigen"
+        aria-pressed="false">
         Validierung (Ringe)
       </button>
       <button 
@@ -85,14 +89,16 @@
         id="layer-sources" 
         class="btn"
         title="Quellen (Marker): zeigt Anzahl/Kategorien pro Land (validation.json)"
-        aria-label="Quellen (Marker) anzeigen">
+        aria-label="Quellen (Marker) anzeigen"
+        aria-pressed="false">
         Quellen (Marker)
       </button>
       <button 
         id="layer-time" 
         class="btn"
         title="Zeitreise durch historische Daten (2000-2025)"
-        aria-label="Zeitreise-Modus aktivieren">
+        aria-label="Zeitreise-Modus aktivieren"
+        aria-pressed="false">
         Zeitreise ⏱️
       </button>
     </div>


### PR DESCRIPTION
💡 What: Added explicit `aria-pressed` attributes to the map layer toggle buttons in the control header. The state dynamically updates in `app.js` when layers are switched.
🎯 Why: The layer control buttons act like a toggle group (where only one is active at a time). While the active button was visually styled (using `btn--primary`), this state was not communicated to screen reader users, making it impossible for them to know which map layer is currently active.
📸 Before/After: Before, buttons only had `aria-label`. After, they explicitly state `aria-pressed="true"` or `aria-pressed="false"`.
♿ Accessibility: Improves keyboard and screen reader navigation by correctly announcing the active state of layer toggle controls.

---
*PR created automatically by Jules for task [17495467553542479803](https://jules.google.com/task/17495467553542479803) started by @karlitos1337*