### PR TITLE
🎨 Palette: Add ARIA labels to icon-only navigation buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,6 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+## 2026-05-29 - Add ARIA Labels to Icon-only Navigation Buttons
+**Learning:** Icon-only buttons used for primary navigation and theme toggling lack screen-reader context. Essential for main UI controls to always include aria-label.
+**Action:** Added aria-label attributes and focus-visible outlines to icon buttons for better keyboard and screen-reader accessibility.

--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, useScroll, useSpring } from 'framer-motion';
 import { Sun, Moon, Menu, X } from 'lucide-react';
 
@@ -24,16 +24,6 @@ const App = () => {
     restDelta: 0.001
   });
 
-  const sections = [
-    { id: 'einleitung', label: 'Einleitung' },
-    { id: 'framework', label: '5D-Intelligence Framework' },
-    { id: 'methodologie', label: 'Methodik' },
-    { id: 'ergebnisse', label: 'Ergebnisse' },
-    { id: 'validierung', label: 'Validierung' },
-    { id: 'implikationen', label: 'Implikationen' },
-    { id: 'zukunft', label: 'Zukunftsperspektiven' },
-    { id: 'schlussfolgerung', label: 'Schlussfolgerung' }
-  ];
 
   useEffect(() => {
     document.querySelectorAll('[data-ref]').forEach(el => {
@@ -91,13 +81,6 @@ const App = () => {
         const section = sectionElements[i];
         if (section && scrollPosition >= section.offsetTop) {
           setActiveSection(section.id);
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 200;
-
-      for (let i = sections.length - 1; i >= 0; i--) {
-        const section = document.getElementById(sections[i].id);
-        if (section && scrollPosition >= section.offsetTop) {
-          setActiveSection(sections[i].id);
           break;
         }
       }
@@ -144,8 +127,9 @@ const App = () => {
 
             <div className="flex items-center space-x-4">
               <button
+                aria-label="Toggle dark mode"
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
+                className={`p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -153,8 +137,9 @@ const App = () => {
               </button>
 
               <button
+                aria-label="Toggle mobile menu"
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -408,7 +393,7 @@ const App = () => {
               <div className={`p-6 rounded-xl ${darkMode ? 'bg-gray-800' : 'bg-gray-50'} shadow-lg`}>
                 <h3 className="text-xl font-semibold mb-4">Reliabilität</h3>
                 <p className="mb-4" data-ref="https://www.sbp-journal.com/index.php/sbp/article/view/13907|11">
-                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach's Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
+                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach&apos;s Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
                 </p>
                 <div className="space-y-2">
                   <div className="flex justify-between">


### PR DESCRIPTION
💡 What: Added aria-label attributes and focus-visible styling to the dark mode toggle and mobile menu buttons. Also fixed existing syntax errors to ensure linting and building succeed.
🎯 Why: Icon-only buttons without text content are inaccessible to screen readers, and lack of focus states makes keyboard navigation difficult.
📸 Before/After: N/A (Visual change is only visible on keyboard focus)
♿ Accessibility: Screen reader users can now understand the purpose of the navigation and theme toggle buttons. Keyboard users have a clear visual indicator of focus state.

---
*PR created automatically by Jules for task [6877340489162039401](https://jules.google.com/task/6877340489162039401) started by @karlitos1337*