### PR TITLE
🎨 Palette: Add ARIA labels and focus states to icon-only navigation buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,6 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+## 2026-05-30 - Missing ARIA Labels on Icon Buttons
+**Learning:** Icon-only navigation buttons in React applications frequently lack screen reader accessibility and clear keyboard focus states.
+**Action:** Always add dynamic aria-labels based on state and ensure focus-visible utility classes are applied for keyboard accessibility.

--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, useScroll, useSpring } from 'framer-motion';
 import { Sun, Moon, Menu, X } from 'lucide-react';
 
-const sections = [
+const APP_SECTIONS = [
   { id: 'einleitung', label: 'Einleitung' },
   { id: 'framework', label: '5D-Intelligence Framework' },
   { id: 'methodologie', label: 'Methodik' },
@@ -23,17 +23,6 @@ const App = () => {
     damping: 30,
     restDelta: 0.001
   });
-
-  const sections = [
-    { id: 'einleitung', label: 'Einleitung' },
-    { id: 'framework', label: '5D-Intelligence Framework' },
-    { id: 'methodologie', label: 'Methodik' },
-    { id: 'ergebnisse', label: 'Ergebnisse' },
-    { id: 'validierung', label: 'Validierung' },
-    { id: 'implikationen', label: 'Implikationen' },
-    { id: 'zukunft', label: 'Zukunftsperspektiven' },
-    { id: 'schlussfolgerung', label: 'Schlussfolgerung' }
-  ];
 
   useEffect(() => {
     document.querySelectorAll('[data-ref]').forEach(el => {
@@ -82,22 +71,13 @@ const App = () => {
   };
 
   useEffect(() => {
-    const sectionElements = sections.map(s => document.getElementById(s.id)).filter(Boolean);
-
     const handleScroll = () => {
       const scrollPosition = window.scrollY + 200;
 
-      for (let i = sectionElements.length - 1; i >= 0; i--) {
-        const section = sectionElements[i];
+      for (let i = APP_SECTIONS.length - 1; i >= 0; i--) {
+        const section = document.getElementById(APP_SECTIONS[i].id);
         if (section && scrollPosition >= section.offsetTop) {
-          setActiveSection(section.id);
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 200;
-
-      for (let i = sections.length - 1; i >= 0; i--) {
-        const section = document.getElementById(sections[i].id);
-        if (section && scrollPosition >= section.offsetTop) {
-          setActiveSection(sections[i].id);
+          setActiveSection(APP_SECTIONS[i].id);
           break;
         }
       }
@@ -127,7 +107,7 @@ const App = () => {
 
             {/* Desktop Navigation */}
             <nav className="hidden md:flex space-x-8">
-              {sections.map((section) => (
+              {APP_SECTIONS.map((section) => (
                 <button
                   key={section.id}
                   onClick={() => scrollToSection(section.id)}
@@ -145,7 +125,8 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+                className={`p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -154,7 +135,8 @@ const App = () => {
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={mobileMenuOpen ? 'Close mobile menu' : 'Open mobile menu'}
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -172,7 +154,7 @@ const App = () => {
             className={`md:hidden border-t ${darkMode ? 'bg-gray-900/95 border-gray-700' : 'bg-white/95 border-gray-200'}`}
           >
             <div className="px-4 py-2 space-y-1">
-              {sections.map((section) => (
+              {APP_SECTIONS.map((section) => (
                 <button
                   key={section.id}
                   onClick={() => scrollToSection(section.id)}
@@ -408,7 +390,7 @@ const App = () => {
               <div className={`p-6 rounded-xl ${darkMode ? 'bg-gray-800' : 'bg-gray-50'} shadow-lg`}>
                 <h3 className="text-xl font-semibold mb-4">Reliabilität</h3>
                 <p className="mb-4" data-ref="https://www.sbp-journal.com/index.php/sbp/article/view/13907|11">
-                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach's Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
+                  Die interne Konsistenz der einzelnen Dimensionen wird mittels Cronbach&apos;s Alpha gemessen. Die Zielvorgabe ist α &gt; 0.8 für hohe Reliabilität.
                 </p>
                 <div className="space-y-2">
                   <div className="flex justify-between">


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the dark mode and mobile menu toggle buttons, and improved keyboard focus visibility using `focus-visible:ring-2` utility classes. 🎯 Why: Icon-only buttons are invisible to screen readers without explicit labels, and keyboard users need clear focus indicators to navigate the UI effectively. 📸 Before/After: Buttons previously lacked semantic meaning for assistive technologies and had no distinct focus ring when tabbed to. Now they dynamically announce their state and highlight clearly on focus. ♿ Accessibility: Improved screen reader support and keyboard navigation for core navigation controls.

---
*PR created automatically by Jules for task [13789601542638252577](https://jules.google.com/task/13789601542638252577) started by @karlitos1337*