### PR TITLE
🎨 Palette: Add keyboard accessibility to map legend and slider

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,8 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+
+
+## 2026-06-04 - [Accessibility] Keyboard Navigation for Custom Interactive Elements
+**Learning:** When building custom interactive elements (like clickable map legends) using standard `div` or `span` tags, they inherently lack keyboard accessibility. While mouse users can click them, keyboard users cannot navigate to them or activate them using Enter or Space.
+**Action:** Always add `role="button"`, `tabindex="0"`, and a `keydown` event listener handling Enter and Space keys to custom interactive elements to ensure full keyboard navigability and accessibility.

--- a/web/5d-map/app.js
+++ b/web/5d-map/app.js
@@ -144,6 +144,7 @@ async function init() {
     selectedYear = Number(e.target.value);
     const label = document.getElementById('year-label');
     if (label) label.textContent = String(selectedYear);
+    e.target.setAttribute('aria-valuenow', selectedYear);
     updateTimeLayer(selectedYear);
   });
 

--- a/web/5d-map/index.html
+++ b/web/5d-map/index.html
@@ -105,7 +105,7 @@
     </div>
     <div id="time-controls" style="display:none;padding:0.5rem 1rem;max-width:480px;margin:0.5rem;background:#fffffe;border:1px solid #e0e0e0;border-radius:0.5rem;">
       <label for="year-slider"><strong>Jahr: <span id="year-label">—</span></strong></label>
-      <input type="range" id="year-slider" min="2000" max="2025" value="2025" step="1" style="width:100%;" />
+      <input type="range" id="year-slider" min="2000" max="2025" value="2025" step="1" style="width:100%;" aria-valuemin="2000" aria-valuemax="2025" aria-valuenow="2025" aria-label="Jahresauswahl" />
       <small>Zeigt Heatmap für ausgewähltes Jahr (Depression/Dropout). Fallback: Nur vorhandene Werte.</small>
     </div>
   </main>

--- a/web/5d-map/modules/layers.js
+++ b/web/5d-map/modules/layers.js
@@ -172,9 +172,20 @@ export function createValidationLegendControl() {
 
       row.style.cursor = 'pointer';
       row.title = 'Klicken zum Filtern';
-      row.addEventListener('click', () => {
+      row.setAttribute('role', 'button');
+      row.setAttribute('tabindex', '0');
+
+      const triggerFilter = () => {
         const ev = new CustomEvent('validation-filter', { detail: { status: r.status } });
         window.dispatchEvent(ev);
+      };
+
+      row.addEventListener('click', triggerFilter);
+      row.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          triggerFilter();
+        }
       });
       div.appendChild(row);
     });


### PR DESCRIPTION
💡 What: Added `role="button"`, `tabindex="0"`, and keydown event handlers to the interactive map legend rows. Added aria labels and dynamic `aria-valuenow` to the year slider.
🎯 Why: The legend rows act as filters but were previously inaccessible to keyboard users. The year slider lacked context for screen readers.
📸 Before/After: Interactive items can now be focused via keyboard and triggered with Enter/Space. Screen readers now announce the year slider value.
♿ Accessibility: Restored full keyboard navigability to custom interactive elements and added ARIA metadata.

---
*PR created automatically by Jules for task [17991270377534304987](https://jules.google.com/task/17991270377534304987) started by @karlitos1337*