### PR TITLE
🎨 Palette: Add ARIA labels to icon-only navigation buttons

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -145,6 +145,7 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
+                aria-label="Toggle dark mode"
                 className={`p-2 rounded-lg transition-colors duration-200 ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
@@ -154,6 +155,7 @@ const App = () => {
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+                aria-label="Toggle mobile menu"
                 className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only dark mode toggle and mobile menu toggle buttons in the main navigation.
🎯 Why: Icon-only buttons without accessible names are completely invisible to screen readers, leaving users guessing what the buttons do. Adding ARIA labels makes these key navigation controls accessible to assistive technologies.
📸 Before/After: Visuals remain unchanged, but the accessible DOM tree now exposes descriptive labels.
♿ Accessibility: Improved screen reader navigation by ensuring all interactive elements have programmatic labels.

---
*PR created automatically by Jules for task [6890598985462244929](https://jules.google.com/task/6890598985462244929) started by @karlitos1337*