### PR TITLE
🎨 Palette: Add aria-pressed to layer toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,7 @@
 ## 2025-04-04 - [Accessibility] Missing semantic ARIA and dynamic focus labels
 **Learning:** When dealing with interactive icon buttons in React SPAs, a common anti-pattern is leaving them unlabelled for screen readers, meaning only their visual presence provides context. Additionally, applying standard tailwind focus styles to fixed headers over dynamic dark mode backgrounds can result in poor contrast for keyboard focus rings. Adding semantic labels (`aria-label`, `title`) and state-aware focus styles vastly improves accessibility with minimal code changes.
 **Action:** Ensure icon-only buttons always include `aria-label` and `title` tags corresponding to their function and state. Use dynamic template literals to adjust `focus-visible` classes based on the current background state, ensuring high contrast visibility for keyboard users.
+
+## 2026-06-09 - Add aria-pressed to layer toggle buttons
+**Learning:** For groups of buttons that act like tabs or toggles (like map layers), adding `aria-pressed="true"`/`"false"` is critical for screen reader users to understand which state is currently active, as visual cues like `btn--primary` are not announced.
+**Action:** Always ensure that visual active states for buttons are paired with their corresponding ARIA state attributes (`aria-pressed` or `aria-current`), and that these attributes are dynamically updated in JavaScript when the state changes.

--- a/web/5d-map/app.js
+++ b/web/5d-map/app.js
@@ -41,9 +41,19 @@ function activateLayer(layerName) {
     infoTextEl.textContent = txt;
     infoEl.style.display = 'block';
   }
-  document.querySelectorAll('.btn').forEach(btn => btn.classList.remove('btn--primary'));
+  document.querySelectorAll('.btn').forEach(btn => {
+    btn.classList.remove('btn--primary');
+    if (btn.hasAttribute('aria-pressed')) {
+      btn.setAttribute('aria-pressed', 'false');
+    }
+  });
   const btn = document.getElementById(`layer-${layerName}`);
-  if (btn) btn.classList.add('btn--primary');
+  if (btn) {
+    btn.classList.add('btn--primary');
+    if (btn.hasAttribute('aria-pressed')) {
+      btn.setAttribute('aria-pressed', 'true');
+    }
+  }
 
   switch (layerName) {
     case 'status-quo':

--- a/web/5d-map/index.html
+++ b/web/5d-map/index.html
@@ -34,6 +34,7 @@
       <button 
         id="layer-status-quo" 
         class="btn btn--primary"
+        aria-pressed="true"
         title="Zeigt Heatmap für Depression & Dropout-Raten weltweit"
         aria-label="Status Quo Heatmap anzeigen">
         Status Quo
@@ -48,6 +49,7 @@
       <button 
         id="layer-schools" 
         class="btn"
+        aria-pressed="false"
         title="Alternative Schulmodelle: Sudbury, Waldorf, Folk High Schools, Tokkatsu"
         aria-label="Alternative Schulen auf Karte anzeigen">
         Alternative Schulen
@@ -55,6 +57,7 @@
       <button 
         id="layer-imp" 
         class="btn"
+        aria-pressed="false"
         title="Intrinsisches Motivationspotenzial (IMP = A×IM×R×SP×Au)"
         aria-label="IMP-Score Choropleth anzeigen">
         IMP‑Score
@@ -62,6 +65,7 @@
       <button 
         id="layer-validation" 
         class="btn"
+        aria-pressed="false"
         title="Validierung (Ringe): zeigt Länder/Regionen mit extern verifizierten Daten (validation.json)"
         aria-label="Validierung (Ringe) anzeigen">
         Validierung (Ringe)
@@ -84,6 +88,7 @@
       <button 
         id="layer-sources" 
         class="btn"
+        aria-pressed="false"
         title="Quellen (Marker): zeigt Anzahl/Kategorien pro Land (validation.json)"
         aria-label="Quellen (Marker) anzeigen">
         Quellen (Marker)
@@ -91,6 +96,7 @@
       <button 
         id="layer-time" 
         class="btn"
+        aria-pressed="false"
         title="Zeitreise durch historische Daten (2000-2025)"
         aria-label="Zeitreise-Modus aktivieren">
         Zeitreise ⏱️


### PR DESCRIPTION
**💡 What:** Added `aria-pressed` attributes to the map layer toggle buttons, dynamically updating them in `app.js` when layers are switched.
**🎯 Why:** Screen reader users rely on semantic ARIA attributes to understand button states. Visual cues like `btn--primary` are not announced, making it impossible to know which map layer is active without `aria-pressed`.
**📸 Before/After:** Screen readers previously announced simply "Status Quo Heatmap anzeigen, button". Now they announce "Status Quo Heatmap anzeigen, toggle button, pressed".
**♿ Accessibility:** Improved state communication for screen readers by adding and dynamically managing the `aria-pressed` state for toggle buttons.

---
*PR created automatically by Jules for task [2142507903431238888](https://jules.google.com/task/2142507903431238888) started by @karlitos1337*