### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in error handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** Client-side encryption of an API key using a hardcoded passphrase before storing it in `localStorage` provides no actual security (security theater) and gives a false sense of protection, while a heuristic scanner could flag it.
 **Learning:** Avoid security theater practices. Store user-provided keys directly in `localStorage` and rename variables/DOM IDs to generic terms (like `serviceToken`) to avoid false positives from CodeQL's clear-text storage rules.
 **Prevention:** Removed `CryptoJS` encryption, directly stored the key in `localStorage`, and renamed `apiKey` references to `serviceToken` across the file.
+
+## 2025-05-18 - [DOM-Based XSS in Error Handling]
+**Vulnerability:** The error handler in `web/templates/5d_forschungsplanung.html` injected `error.message` directly into the DOM using `innerHTML` and a template literal, creating a DOM-based XSS vulnerability if an attacker controls the error message.
+**Learning:** Never use `innerHTML` to display dynamic error messages, even in catch blocks. Attackers can sometimes manipulate network responses or error states to trigger XSS.
+**Prevention:** Replaced `innerHTML` with creating a `<p>` element and using `textContent` to safely assign the error message.

--- a/web/templates/5d_forschungsplanung.html
+++ b/web/templates/5d_forschungsplanung.html
@@ -697,7 +697,11 @@
                 }
             } catch (error) {
                 loadingSpinner.classList.add('hidden');
-                aiResponse.innerHTML = `<p class="text-red-500">Netzwerkfehler: ${error.message}</p>`;
+                aiResponse.innerHTML = '';
+                const p = document.createElement('p');
+                p.className = 'text-red-500';
+                p.textContent = `Netzwerkfehler: ${error.message}`;
+                aiResponse.appendChild(p);
             }
         }
     </script>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The error handler in `web/templates/5d_forschungsplanung.html` directly assigned an unescaped `error.message` via `innerHTML` and a template literal, creating a DOM-based XSS vulnerability.
🎯 Impact: Attackers who can control network errors or manipulate the fetch response could execute arbitrary JavaScript within the user's session.
🔧 Fix: Used `document.createElement('p')` and `textContent` to safely treat the error message as literal text.
✅ Verification: Ran the test suite using `pytest` and successfully verified the code structure visually to ensure safe node injection.

---
*PR created automatically by Jules for task [9249503234750694838](https://jules.google.com/task/9249503234750694838) started by @karlitos1337*