### PR TITLE
⚡ Bolt: Add lazy loading to off-screen images

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -243,6 +243,7 @@ const App = () => {
                     alt="Eine moderne Infografik, die die fünf Dimensionen des 5D-Intelligence Frameworks visuell darstellt. Die Grafik zeigt ein zentrales Symbol in Form eines menschlichen Gehirns oder einer Blume mit fünf ausgehenden Strahlen, die jeweils eine der Dimensionen repräsentieren. Jeder Strahl ist farbcodiert: Blau für Autonomie, Grün für intrinsische Motivation, Gelb für Resilienz, Rot für soziale Partizipation und Lila für Authentizität. Um das Zentrum herum befinden sich stilisierte Symbole, die mit jeder Dimension assoziiert werden: eine freie Hand für Autonomie, eine Flamme für Motivation, einen Baum für Resilienz, eine Gruppe von Personen für soziale Partizipation und einen Spiegel für Authentizität. Der Hintergrund ist hell mit subtilen geometrischen Mustern, und alle Elemente sind in einem modernen, flachen Designstil gehalten."
                     className="w-full rounded-xl shadow-lg"
                     data-ref="https://selfdeterminationtheory.org/theory/|6"
+                    loading="lazy" /* ⚡ Bolt Optimization: Defer loading off-screen image */
                 />
               </div>
             </div>
@@ -365,6 +366,7 @@ const App = () => {
                   alt="Ein wissenschaftliches Diagramm mit zwei Achsen, das die Beziehung zwischen Autonomie und sozioökonomischen Ergebnissen visualisiert. Die x-Achse ist beschriftet mit 'Autonomie-Score (0-100)' und die y-Achse mit 'Sozioökonomische Ergebnisse (0-100)'. Punkte sind als blaue Kreise dargestellt, die eine positive Korrelation zeigen. Eine durchgezogene Linie verläuft diagonal von unten links nach oben rechts, die die Regressionslinie darstellt. Oben im Diagramm steht der Titel 'Korrelation zwischen Autonomie und sozioökonomischen Outcomes (r = 0.68-0.73)' in großer, fettgedruckter Schrift. Die Diagrammfläche hat einen hellen Hintergrund mit subtilen Gitterlinien, und die Achsen sind klar beschriftet mit schwarzer Schrift auf weißem Hintergrund."
                   className="w-full rounded-xl shadow-lg"
                   data-ref="https://www.researchgate.net/publication/369555022_Global_High-Resolution_Estimates_of_the_United_Nations_Human_Development_Index_Using_Satellite_Imagery_and_Machine-Learning|1"
+                  loading="lazy" /* ⚡ Bolt Optimization: Defer loading off-screen image */
               />
             </div>
 


### PR DESCRIPTION
💡 What: Added `loading="lazy"` attribute to the two off-screen infographic images in the Validation Dashboard.
🎯 Why: To defer loading of below-the-fold images, improving the initial page load performance and reducing unnecessary network requests on initial render.
📊 Impact: Reduces initial page weight and improves Time to Interactive (TTI) by deferring off-screen asset loading.
🔬 Measurement: Verify by checking the network tab in DevTools; the images should only load when scrolling down to their respective sections.

---
*PR created automatically by Jules for task [16466708459857941044](https://jules.google.com/task/16466708459857941044) started by @karlitos1337*