### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to icon buttons

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -113,7 +113,7 @@ const App = () => {
                 <button
                   key={section.id}
                   onClick={() => scrollToSection(section.id)}
-                  className={`text-sm font-medium transition-colors duration-200 ${
+                  className={`text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm ${
                     activeSection === section.id
                       ? (darkMode ? 'text-blue-400' : 'text-blue-600')
                       : (darkMode ? 'text-gray-300 hover:text-white' : 'text-gray-600 hover:text-gray-900')
@@ -127,7 +127,9 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={darkMode ? 'Light mode aktivieren' : 'Dark mode aktivieren'}
+                title={darkMode ? 'Light mode' : 'Dark mode'}
+                className={`p-2 rounded-lg transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -136,7 +138,9 @@ const App = () => {
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
+                aria-label={mobileMenuOpen ? 'Menü schließen' : 'Menü öffnen'}
+                aria-expanded={mobileMenuOpen}
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                   darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
                 }`}
               >
@@ -158,7 +162,7 @@ const App = () => {
                 <button
                   key={section.id}
                   onClick={() => scrollToSection(section.id)}
-                  className={`block w-full text-left px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 ${
+                  className={`block w-full text-left px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                     activeSection === section.id
                       ? (darkMode ? 'text-blue-400 bg-gray-800' : 'text-blue-600 bg-gray-100')
                       : (darkMode ? 'text-gray-300 hover:text-white hover:bg-gray-800' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100')


### PR DESCRIPTION
💡 What:
- Added `aria-label` and `title` to dark mode toggle button.
- Added `aria-label` and `aria-expanded` to mobile menu toggle button.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` to all interactive buttons for better keyboard navigation visibility.

🎯 Why:
Icon-only buttons are difficult for screen reader users to understand. The mobile menu state wasn't communicated, and keyboard focus states were missing or subtle.

📸 Before/After:
Added focus rings on hover and keyboard tab interaction.

♿ Accessibility:
Improved screen reader compatibility and keyboard navigation.

---
*PR created automatically by Jules for task [4306006144470866314](https://jules.google.com/task/4306006144470866314) started by @karlitos1337*