### PR TITLE
🎨 Palette: Add skip link and dynamic focus styles for icon buttons

### DIFF
--- a/web/validation_dashboard/src/App.jsx
+++ b/web/validation_dashboard/src/App.jsx
@@ -91,6 +91,12 @@ const App = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${darkMode ? 'bg-gray-900 text-gray-100' : 'bg-white text-gray-900'}`}>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-blue-600 focus:text-white focus:top-0 focus:left-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+      >
+        Zum Hauptinhalt springen
+      </a>
       {/* Progress bar */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 bg-blue-500 transform-origin-left z-50"
@@ -127,18 +133,23 @@ const App = () => {
             <div className="flex items-center space-x-4">
               <button
                 onClick={toggleDarkMode}
-                className={`p-2 rounded-lg transition-colors duration-200 ${
-                  darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
+                className={`p-2 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                  darkMode ? 'hover:bg-gray-700 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900' : 'hover:bg-gray-100 focus-visible:ring-offset-2 focus-visible:ring-offset-white'
                 }`}
+                aria-label={darkMode ? 'Hellen Modus aktivieren' : 'Dunklen Modus aktivieren'}
+                title={darkMode ? 'Hellen Modus aktivieren' : 'Dunklen Modus aktivieren'}
               >
                 {darkMode ? <Sun size={20} /> : <Moon size={20} />}
               </button>
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className={`md:hidden p-2 rounded-lg transition-colors duration-200 ${
-                  darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
+                className={`md:hidden p-2 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                  darkMode ? 'hover:bg-gray-700 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900' : 'hover:bg-gray-100 focus-visible:ring-offset-2 focus-visible:ring-offset-white'
                 }`}
+                aria-label={mobileMenuOpen ? 'Menü schließen' : 'Menü öffnen'}
+                title={mobileMenuOpen ? 'Menü schließen' : 'Menü öffnen'}
+                aria-expanded={mobileMenuOpen}
               >
                 {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
               </button>
@@ -173,7 +184,7 @@ const App = () => {
       </header>
 
       {/* Main Content */}
-      <main className="pt-16">
+      <main id="main-content" tabIndex="-1" className="pt-16 outline-none">
         {/* Hero Section */}
         <section id="einleitung" className={`py-20 ${darkMode ? 'bg-gradient-to-br from-gray-800 to-gray-900' : 'bg-gradient-to-br from-blue-50 to-indigo-100'}`}>
           <div className="max-w-4xl mx-auto px-6 text-center">


### PR DESCRIPTION
💡 What:\n- Added a 'Zum Hauptinhalt springen' skip link targeted at the main content.\n- Added `aria-label` and `title` attributes to the theme toggle and mobile menu buttons.\n- Added dynamic `focus-visible` offset ring styles to these buttons based on light/dark mode.\n\n🎯 Why:\n- Improves accessibility by providing a way for keyboard users to skip the header navigation.\n- Ensures icon-only interactive elements are accessible to screen readers and have clear keyboard focus indicators even on varying backgrounds.\n\n📸 Before/After:\n(Video and screenshot generated via Playwright verification)\n\n♿ Accessibility:\n- Added skip to content link functionality.\n- Improved screen reader support with explicit ARIA labels on icon-only buttons.\n- Enhanced keyboard navigability with proper contrast focus styles in both themes.

---
*PR created automatically by Jules for task [12284208798517862628](https://jules.google.com/task/12284208798517862628) started by @karlitos1337*